### PR TITLE
Updating About Pages (issue #16)

### DIFF
--- a/aboutDLX.html
+++ b/aboutDLX.html
@@ -7,10 +7,72 @@
 	<meta name=description content='The about page of Digital Linguistics'>
 	<meta name=keywords content='wugbot, digital linguistics, DLX, linguistics, computational linguistics, language revitalization'>
 	
-	<link rel='stylesheet' type='text/css' href='css/style.css'>
+	<!--- <link rel='stylesheet' type='text/css' href='css/style.css'> --->
 </head>
+
+<style>
+body{
+	margin: 2%;
+    margin-right: 25%; }
+
+ul {
+    list-style-type: square;
+    padding-left: 50px; 
+    padding-right: 75px; }
+
+ul li {
+    padding: 4px 0px;}
+
+
+</style>
+
 <body>
-digital linguistics
+<h2>Frequently Asked Questions</h2>
+<ul>
+<li><a href="#digital">Isn't linguistics already digital? Why do we need digital linguistics?</a></li>
+<li><a href="#theory">How does digital linguistics fit into existing linguistic theory?</a></li>
+<li><a href="#why-web">Why use the web for digital linguistics?</a></li>
+
+
+</ul>
+
+<h2 id="digital">Isn't linguistics already digital? What is digital linguistics?</h2>
+
+<p>No. We maintain that digital linguistics doesn't exist yet, and will not exist until we escape the print way of thinking about data. Moreover, the digital tools of linguistics are currently fractured. Each current piece of software is in itself helpful in various ways, but many of these programs are operating-system dependent, and generally only accomplish only a small portion of what the linguist needs to do. Our goal with Wugbot is not to fix this by making one application that can do <strong>everything</strong>, but rather to create the standards and the infrastructure so that the software programs that linguists build can speak to each other. In other words, we want to create an interface for documenting data, analyzing data, and archiving data. This interface will be able to pass data easily between different tools and, because we separate data from presentation, visualize that data in different ways.</p>
+
+<p>Many linguists and computer scientists make a clear delineation between linguistics and computer science. We do not. Digital linguistics does not shy away from implementation issues, usability, or software development, because we recognize that these technologies are not different in principle from technologies like interlinear glossing or audio equipment, all of which form an integral part of the linguistic enterprise. These technology-related issues are not the focus of digital linguistics, but they must be dealt with adequately in order for the field of linguistics to progress successfully. Just as the documentary linguist is expected to understand some of the basic principles of audio formats and recording, we believe it is important that today's linguist have a basic understanding of data structure as it relates to the digital representation of data. We also feel that this is easy for any linguist to learn, and hope our tools can help teach linguists these skills.
+
+<p>Thus we incorporate software development into the core goalset of the digital linguistics subfield. We encourage linguists and language workers to choose the level of technical proficiency they desire to have. Whatever that level is, the digitally-informed linguist has an important role to play in the goal of bringing digital technologies to linguistics. We value complaints, feedback, and ideas for improvement, because this is an integral part of the software development process, and how new technologies are created. We believe that progress in the field of digital linguistics should be evaluated in terms of how populizable the outputs of the field are, i.e. the extent to which the tools created with Wugbot's' methodology gain traction in the field of linguistics more broadly.</p>
+
+
+<h2 id="theory">Digital Linguistics and Lingusitic Theory</h2>
+
+<p>Digital linguistics forces linguists - and especially those creating the tools of digital linguistics - to think deeply and carefully about the objects of linguistics and the nature of linguistic data. A famous scientist once remarked, 'You can understand when you are able to quantify it', but the much-admired phonetician Peter Ladefoged quipped instead, 'You can understand a thing when you can write a computer program to represent it.' In our experience, this has often been the case. Learning how to represent linguistic data has gotten us to think about the basic concepts of linguistics in often new ways that yield insights into linguistic science, or what it is we're really doing when we represent certain things in print.</p>
+
+<!-- I think this section will need to be cleaned up and explained in detail in layman's term. We'll also need to explain how Wugbot achieves these goals. I haven't read Bird and Simon 2003 yet, but I can get to this later.
+
+<p>Using the web platform also meets many of the goals of the <a href="http://www.language-archives.org/documents/portability.pdf">Bird and Simons (2003)<a> model for portability:</p>
+
+<ul>
+<li>Content - terminology, accountability, richness</li>
+<li>Format - openness, documentation, machine-readable, human-readable</li>
+<li>Discovery - existence, relevance</li>
+<li>Access - complete, unimpeded, universal</li>
+<li>Citation - credit, provenance, persistence, immutability, components</li>
+<li>Preservation - long-term, complete 1. Rights -documentation, research</li>
+<li>Rights -documentation, research</li>
+</ul>
+
+We should also link Pat's MA thesis here.
+
+-->
+
+<h2 id="why-web">Why the web?</h2>
+
+<p>Wugbot uses the web as its platform. Ironically, this does not mean that everything we do is online. Rather, web technologies have become so robust that their applications now extend far beyond exchanging data across the internet. It is now possible to write a program that works in web browsers like Internet Explorer, Firefox, Chrome, Safari, etc., that never has to go online at all. These offline applications are ideal because anybody with a web browser can use them. They don't depend on whether you are running Windows, Mac, Android or Linux, and they don't depend on an internet connection. In short, the browser becomes the program.</p>
+
+<p>At the same time, digital linguistics technologies can take advantage of data exchange across the web, allowing linguists to store their data on a server (only if they want), and contribute to massive cross-linguistic databases for linguistic research.</p>
+
 	<script src='js/script.js'></script>
 </body>
 </html>

--- a/aboutDLX.html
+++ b/aboutDLX.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang=en>
+<head>
+	<meta charset=utf-8>
+	<title>About Digital Linguistics</title>
+	<meta name=author content='The Wugbot Team'>
+	<meta name=description content='The about page of Digital Linguistics'>
+	<meta name=keywords content='wugbot, digital linguistics, DLX, linguistics, computational linguistics, language revitalization'>
+	
+	<link rel='stylesheet' type='text/css' href='css/style.css'>
+</head>
+<body>
+digital linguistics
+	<script src='js/script.js'></script>
+</body>
+</html>

--- a/aboutWugbot.html
+++ b/aboutWugbot.html
@@ -5,26 +5,94 @@
 	<title>About Wugbot</title>
 	<meta name=author content='The Wugbot Team'>
 	<meta name=description content='The about of Wugbot - an organization dedicated to making digital linguistics accessible to everyone'>
-	<meta name=keywords content='wugbot, digital linguistics, DLX, linguistics, computational linguistics, language revitalization'>
+	<meta name=keywords content='Wugbot, digital linguistics, DLX, linguistics, computational linguistics, language revitalization'>
 	
-	<link rel='stylesheet' type='text/css' href='css/style.css'>
+<!---	<link rel='stylesheet' type='text/css' href='css/style.css'> --->
 </head>
+
+<style>
+body{
+	margin: 2%;
+    margin-right: 25%; }
+
+ul {
+    list-style-type: square;
+    padding-left: 50px; 
+    padding-right: 75px; }
+
+ul li {
+    padding: 4px 0px;}
+
+
+</style>
+
 <body>
 
 <h2>Mission Statement</h2>
 
-<p>We aim to build tools, documentation, and example applications to help the field of linguistics reap more benefits from digitization. We have chosen the web platform as a suitable platform for this work.</p>
+<p>We aim to build tools, documentation, and example applications to help the field of linguistics reap more benefits from digitization. In other words, we plan to write programs, and to teach other linguists how to write programs, so they can take advantage of technology when doing linguistic research. We have chosen the web platform as a suitable platform for this work.</p>
+
+<h2>Frequently Asked Questions</h2>
+
+<ul>
+<li><a href="#why-web">Why is the web a suitable platform for Wugbot?</a></li>
+<li><a href="#short-term">What are Wugbot's short term goals?</a></li>
+<li><a href="#long-term">What are Wugbot's long term goals?</a></li>
+<li><a href="#open-source">What is "open source"? Why is it important for Wugbot?</a></li>
+<li><a href="#open-source-policy">Does open source mean I have to share my data?</a></li>
+<li><a href="/aboutDLX.html">What is "Digital Linguistics"? How does Wugbot contribute to linguistic theory?</a></li>
+
+</ul>
+
+<h2 id="why-web">Why the web?</h2>
 
 <p>We have chosen the web platform for a variety of reasons:
 </p>
 
 <ul>
-<li>No one needs to <em>install</em> or <em>download</em> anything! Anyone with internet access typically has a browser already available on their device.</li>
-<li>The web platform comes with a markup language for <em>organizing data</em> (HTML), an independent markup language for adding <em>styles like colors and fonts</em> (CSS), and a scripting language for <em>manipulating data</em> (JavaScript). </li>
-<li>HTML, CSS, and JavaScript are relatively <em>easy to learn</em> and work together seemlessly <em>across platforms</em>. This means you can make it on Windows, Mac, or Linux and it will work on Internet Explorer, Safari, Firefox, or any other browser.</li>
-<li>
+<li>No one needs to <strong>install</strong> or <strong>download</strong> anything! Most computers, laptops, tablets, and smartphones come with internet browsers and text editors already installed.</li>
+<li>The web platform comes with a markup language for <strong>organizing data</strong> (HTML), an independent markup language for adding <strong>styles like colors and fonts</strong> (CSS), and a scripting language for <strong>manipulating data</strong> (JavaScript). </li>
+<li>HTML, CSS, and JavaScript are relatively <strong>easy to learn</strong> and work together sestronglessly <strong>across platforms</strong>. This means you can make it on Windows, Mac, or Linux and it will work on Internet Explorer, Safari, Firefox, or any other browser.</li>
+<li>This means you have <strong>one standard interface across all devices</strong> instead of having to install (and learn!)  ELAN, FLEx, LexiquePro, Praat, and half a dozen other programs.
+<li>HTML, CSS, and JavaScript have become industry standards. Unlike other technologies, like floppy disks and cassette tapes, these have stood the test of time. They ain't going anywhere any time soon!</li>
+<li>Data can be stored and manipulated locally (off the internet) or publically (on the internet), depending on the needs of your project.</li>
 </ul>
 
-	<script src='js/script.js'></script>
+
+<h2 id="short-term">Wugbot's Short-Term Goals</h2>
+<p> Wugbot has several on-going projects as proof-of-concept test cases for our platform. The aggregate examples will be combined in a way that demonstrates the utility of Wugbot’s efforts for typological linguistic comparison.</p>
+<ul>
+<li><strong>HTML/CSS:</strong> A proposal for a standardized method for marking up linguistic data in HTML and a complementary CSS stylesheets which render the above markup in standard linguistic notation. In other words, a standard for formatting interlinear glosses using HTML and CSS, including example texts.</li>
+<li><strong>JavaScript:</strong> A series of small, interoperable web-based interfaces aimed at solving very specific documentary problems. In other words, several web applications which can do simple tasks like tag parts-of-speech or measure vowel formats.
+<li><strong>Language Documenation:</strong>Multiple-document digitization projects on Hiligaynon (an Austronesian language of the Philippines) and Chitimacha (a langauge isolate spoken in Louisiana).</li>
+<li><strong>Linguistic Typology:</strong>A small-scale multi-language comparative typology project, consisting of a comparison of a single grammatical feature across a broad array of languages.</li>
+
+</ul>
+
+<h2 id="long-term">Wugbot's Long-Term Goals</h2>
+<p>At a later date we may...</p>
+<ul>
+<li>submit our proposals to suitable standards organizations such as <a href="http://www.w3.org/">W3C.org</a> or other similar web standards organizations.)</li>
+<li>set up interactive tutorials, webinars, or host workshops to teach linguists how to use HTML, CSS, JavaScript and other technologies.</li>
+</ul>
+
+<h2 id="open-source">What is open source?</h2>
+
+<p>Our work will be released under open source licenses. What this means is that anyone can use or edit the code Wugbot writes. You can download and use our programs for free, and you are free to make changes or add improvements as you see fit. We encourage derivative works based on the standards, including potentially commercial applications. </p>
+
+<p>We also prioritize the human-legibility of the documentary formats we develop. We try to write transparent code, so that linguists can use our work as a model when learning to program themselves. For example, we try to avoid unnecessary or obtuse abbreviations in the code. While the markup of a detailed HTML file may not be truly “readable,” the rendered version will be, and we insist on maintaining clarity of mapping between markup and rendered content. Many existing software formats (ELAN’s EAF format, Flex’s @@@, etc.) place no such priority on the design of their formats. Thus these formats are confined to being legible only to technical experts and not the majority of linguists. It is our goal to increase the general amount of technical empowerment among working linguists and speech communities. Data formats should become more transparent and more accessible by everyone.</p>
+
+<p>It is for these reasons of accessibility and in the spirit of facilitating technical literacy among linguists and language community members that we have chosen to be part of the <a href="http://en.wikipedia.org/wiki/Open_source">Open Source initiative</a>.
+
+<h2 id="open-source-policy">Policy on Openness of Tools, Not Content</h2>
+
+<p>Wugbot is open source. Your data is still your data, even if you use our tools. You are not obligated to use our tools while connected to the internet, and there is no need to share your data.</p>
+
+<p>The licensing status of the <strong>formats and processes</strong> defined by Wugbot are completely distinct from the licensing of the <strong>content</strong> produced by linguists and speakers. In other words, while you are free to use the programs, you are not free to use data created by our programs. For example, if Wugbot's programs are used to document and archive an endangered language, the content of that language still belongs to the researchers and communities working on it. Only linguists, speakers, and speech communities are capable of determining appropriate ethical constraints on archival material.</p>
+
+<p>Our goal is to enable linguists to collaborate more effectively, while remaining independent of commitment to any particular server infrastructure or curatorial regime. We provide tools to do linguistic analysis and archive languages. However, we <strong>do not</strong> intend recommend or even discuss the ethical status of any documentary output. Those decisions are properly addressed by linguists and the communities they work with, not by a team such as ours, which is focused on technical solutions to documentary problems.</p>
+
+
+<script src='js/script.js'></script>
 </body>
 </html>

--- a/aboutWugbot.html
+++ b/aboutWugbot.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang=en>
+<head>
+	<meta charset=utf-8>
+	<title>About Wugbot</title>
+	<meta name=author content='The Wugbot Team'>
+	<meta name=description content='The about of Wugbot - an organization dedicated to making digital linguistics accessible to everyone'>
+	<meta name=keywords content='wugbot, digital linguistics, DLX, linguistics, computational linguistics, language revitalization'>
+	
+	<link rel='stylesheet' type='text/css' href='css/style.css'>
+</head>
+<body>
+
+<h2>Mission Statement</h2>
+
+<p>We aim to build tools, documentation, and example applications to help the field of linguistics reap more benefits from digitization. We have chosen the web platform as a suitable platform for this work.</p>
+
+<p>We have chosen the web platform for a variety of reasons:
+</p>
+
+<ul>
+<li>No one needs to <em>install</em> or <em>download</em> anything! Anyone with internet access typically has a browser already available on their device.</li>
+<li>The web platform comes with a markup language for <em>organizing data</em> (HTML), an independent markup language for adding <em>styles like colors and fonts</em> (CSS), and a scripting language for <em>manipulating data</em> (JavaScript). </li>
+<li>HTML, CSS, and JavaScript are relatively <em>easy to learn</em> and work together seemlessly <em>across platforms</em>. This means you can make it on Windows, Mac, or Linux and it will work on Internet Explorer, Safari, Firefox, or any other browser.</li>
+<li>
+</ul>
+
+	<script src='js/script.js'></script>
+</body>
+</html>

--- a/css/style.css
+++ b/css/style.css
@@ -47,10 +47,22 @@ blockquote, q {
 blockquote:before, blockquote:after, q:before, q:after {
   content: '';
   content: none; }
+  
+body{
+    width: 800px;
+	margin: 50px;
+	padding: 0px; }
+    
+em {
+    font-weight:bold; }
 
 h1 {
   font-weight: bold;
   text-align: center; }
+
+h2 {
+    font-weight: bold; 
+    font-size: 150%; }
 
 input {
   background-color: lightgray; }
@@ -87,6 +99,11 @@ thead {
 	
 tr {
   display: table-row; }
+
+ul {
+    list-style-type: disc;
+    padding-left: 50px; }
+
 
 /* Styling by DOM elements */
 html, body {


### PR DESCRIPTION
I commented out the style.css link pending
digitallinguistics/introdemo#33

I made fairly substantial changes to the text. The vast majority of
these were to make it as readable as possible to a layperson audience.
I am assuming language community members and non-programmer linguists
will be reading this. I provided examples of things, cleared up jargon,
cut wordiness, etc.

There is a lot of overlap between the DLX page and the Wugbot page (for
example, the “why web?” sections in both). We may need to sit down and
think about what (if anything) is the difference between the two.  I
moved some material from each back and forth between the two pages as
made sense to me.

I feel that the “About Wugbot” page is basically done (other than
headers, navigation bars, CSS, etc.) as far as content-clean up and
organizing in a user-friendly way. I am not done with the AboutDLX page.